### PR TITLE
Update connections.py

### DIFF
--- a/arq/connections.py
+++ b/arq/connections.py
@@ -266,7 +266,7 @@ async def create_pool(
         except (ConnectionError, OSError, RedisError, asyncio.TimeoutError) as e:
             if retry < settings.conn_retries:
                 logger.warning(
-                    'redis connection error %s:%s %s %s, %d retries remaining...',
+                    'redis connection error %s:%s %s %s, %s retries remaining...',
                     settings.host,
                     settings.port,
                     e.__class__.__name__,


### PR DESCRIPTION
Allows values like `float('inf')` to retry infinite. This can be useful in cluster contexts where a redis service might temporarily not available for some reason but you might not want the worker to crash on that but waiting until redis is available again